### PR TITLE
Feat: post_processing and model compare

### DIFF
--- a/code/generation/predict.py
+++ b/code/generation/predict.py
@@ -7,7 +7,12 @@ from transformers import (
 from hanspell import spell_checker
 from soynlp.normalizer import emoticon_normalize
 from quickspacer import Spacer
-
+import re
+from konlpy.tag import Mecab
+from sklearn.feature_extraction.text import TfidfVectorizer
+from kss import split_sentences
+import numpy as np
+import warnings
 spacer = Spacer()
 
 # 맞춤법을 교정합니다.
@@ -20,7 +25,7 @@ class CommentGeneration():
         self.max_length = 512
         self.max_target_length = 128
         self.model = AutoModelForSeq2SeqLM.from_pretrained(self.ckpt_name, max_length=self.max_length)
-
+        warnings.filterwarnings(action='ignore')
         self.device = torch.device(
             'cuda:0' if torch.cuda.is_available() else 'cpu')
         self.model.to(self.device)
@@ -35,13 +40,19 @@ class CommentGeneration():
             comment : 생성된 코맨트
         """
         # 데이터셋 전처리
+        err_char = re.compile('[^\u0000-\u0100\0x1100-0x11FF\u3131-\u3163\uac00-\ud7a3]+')
         inputs = self.spell_check_and_spacing([text])
         inputs = self.tokenizer(inputs, max_length=self.max_length, return_tensors='pt', truncation=True).to(self.device)
         input_ids = inputs["input_ids"]
-        model_outputs = self.model.generate(input_ids, eos_token_id=self.tokenizer.eos_token_id, max_length=self.max_target_length, min_length = 60, num_beams=5,temperature=0.7)
+        model_outputs = self.model.generate(input_ids, eos_token_id=self.tokenizer.eos_token_id, max_length=self.max_target_length, min_length = 30, num_beams=10,temperature=1)
         comment = self.tokenizer.decode(model_outputs[0],skip_special_tokens=True)
         #print(comment)
-        return comment
+        
+        while err_char.search(comment):
+            model_outputs = self.model.generate(input_ids, eos_token_id=self.tokenizer.eos_token_id, max_length=self.max_target_length, min_length = 30, num_beams=10,temperature=1)
+            comment = self.tokenizer.decode(model_outputs[0],skip_special_tokens=True)
+        
+        return self.post_processing(comment)
     
     def spell_check_and_spacing(self, array):
         # 띄어쓰기를 교정합니다.
@@ -60,6 +71,33 @@ class CommentGeneration():
             spell_checked = array
 
         return spell_checked
+
+    def post_processing(self, comment):
+        sentences = split_sentences(comment)
+        tokenizer = Mecab()
+        def tokenized(x):
+            return [i for i in tokenizer.pos(x) if i[1] not in ["JKS","JKC","JKG","JKO","JKB","JKV","JKQ","JX","JC","EP","EF","EC","ETN","ETM"]]
+        vectorizer = TfidfVectorizer(tokenizer=tokenized)
+        sentences =  sorted(set(sentences), key=lambda x: sentences.index(x)) # 중복된 문장 제거
+        del_index = []
+        for i,s_i in enumerate(sentences):
+            query = s_i
+            corpus = [s_j for j,s_j in enumerate(sentences) if i!=j]
+            sp_matrix = vectorizer.fit_transform(corpus)
+            query_vec = vectorizer.transform([query])
+            result = query_vec * sp_matrix.T
+            sorted_result = np.argsort(-result.data)
+            doc_scores = result.data[sorted_result]
+            doc_ids = result.indices[sorted_result]
+            for score,ids in zip(doc_scores,doc_ids):
+                if score>0.7:
+                    del_index.append(ids if i>ids else ids+1)
+        
+        del_index =  sorted(set(del_index))
+        for i in del_index:
+            sentences[i]=""
+        comment = " ".join(sentences)
+        return comment
 
 if __name__ == '__main__':
     preds = CommentGeneration("./models/total_comment_emotion")

--- a/code/main.py
+++ b/code/main.py
@@ -2,11 +2,16 @@ import streamlit as st
 import pandas as pd
 from sentiment_analysis.predict import SentimentAnalysis
 from generation.predict import CommentGeneration
+import re
+
+
 
 # 실행 방법
 # streamlit run main.py --server.fileWatcherType none --server.port=30001
-s_preds = SentimentAnalysis("JunHyung1206/kote_sentiment_roberta_large")
-c_preds = CommentGeneration("./generation/models/total_comment_emotion")
+s_preds = SentimentAnalysis("nlp04/kote_sentiment_roberta_large")
+c_preds = CommentGeneration("nlp04/kobart_8_5.6e-5_default_option")
+c_preds2 = CommentGeneration("nlp04/kobart_8_5.6e-5_min30_lp4_sample")
+
 st.title("ProtoType")
 if 'input' not in st.session_state:
     st.session_state["input"] = ''
@@ -27,8 +32,13 @@ if submit:
     values = [all_score[i] for i in index]
     
     st.markdown('---')
-    st.markdown('### Comment')
+    st.markdown('### nlp04/kobart_8_5.6e-5_default_option Comment')
     st.write(c_preds.comment_generation(st.session_state['input']))
+    st.markdown("---")
+    st.markdown('### nlp04/kobart_8_5.6e-5_min30_lp4_sample Comment')
+    comment = c_preds2.comment_generation(st.session_state['input'])
+    st.write(comment)
+    
     chart_data = pd.DataFrame(values, index=index, columns=["result"])
     
     


### PR DESCRIPTION
## 모델 push_to_hub 완료
`JunHyung1206/kote_sentiment_roberta_large` -> `nlp04/kote_sentiment_roberta_large`
`./generation/models/total_comment_emotion` -> `nlp04/kobart_8_5.6e-5_default_option`

## nlp04/kobart_8_5.6e-5_min30_lp4_sample 추가
- 한글이 깨지는 경우 및 한자가 들어가는 경우 발생 -> `re.compile`로 제거

![image](https://user-images.githubusercontent.com/101449496/214965714-14ff2ef9-552a-4881-b3bb-6d54c1583d87.png)

- TF-IDF를 이용하여 후처리
    - Mecab을 이용하여 불용어 제거
    - BM25같은 경우 문장의 길이에 영향을 많이 받아 TF-IDF 채택
    - 0.7 이상이면 해당 문장 제거
